### PR TITLE
Display a login success message

### DIFF
--- a/src/pam_google_authenticator.c
+++ b/src/pam_google_authenticator.c
@@ -1666,8 +1666,10 @@ static int google_authenticator(pam_handle_t *pamh, int flags,
       updated = 1;
     }
 
-    // If nothing matched, display an error message
-    if (rc != PAM_SUCCESS) {
+    // Display a success or error message
+    if (rc == PAM_SUCCESS) {
+      log_message(LOG_INFO , pamh, "Accepted google_authenticator for %s", username);
+    } else {
       log_message(LOG_ERR, pamh, "Invalid verification code");
     }
   }


### PR DESCRIPTION
I'd like to know the person who logged in by google-authenticator.
`sshd` displays only the following message
```
Nov 16 14:37:57 test01 sshd[30165]: Accepted keyboard-interactive/pam for knqyf263 from 192.168.1.10 port 52712 ssh2
```