### PR TITLE
Fix macOS name for libqrencode

### DIFF
--- a/src/google-authenticator.c
+++ b/src/google-authenticator.c
@@ -208,7 +208,7 @@ static int displayQRCode(const char* url) {
     qrencode = dlopen("libqrencode.so.3", RTLD_NOW | RTLD_LOCAL);
   }
   if (!qrencode) {
-    qrencode = dlopen("libqrencode.dylib.3", RTLD_NOW | RTLD_LOCAL);
+    qrencode = dlopen("libqrencode.3.dylib", RTLD_NOW | RTLD_LOCAL);
   }
   if (!qrencode) {
     return 0;


### PR DESCRIPTION
Use the proper macOS name for libqrencode 3.