### PR TITLE
add support for libqrencode v4

### DIFF
--- a/src/google-authenticator.c
+++ b/src/google-authenticator.c
@@ -208,7 +208,13 @@ static int displayQRCode(const char* url) {
     qrencode = dlopen("libqrencode.so.3", RTLD_NOW | RTLD_LOCAL);
   }
   if (!qrencode) {
+    qrencode = dlopen("libqrencode.so.4", RTLD_NOW | RTLD_LOCAL);
+  }
+  if (!qrencode) {
     qrencode = dlopen("libqrencode.3.dylib", RTLD_NOW | RTLD_LOCAL);
+  }
+  if (!qrencode) {
+    qrencode = dlopen("libqrencode.4.dylib", RTLD_NOW | RTLD_LOCAL);
   }
   if (!qrencode) {
     return 0;


### PR DESCRIPTION
Add support for libqrencode version 4. I was able to test on macOS 10.12 (Sierra), no issues. I haven't tested on Linux but the fix should find v4 on other platforms as well.

I'm working on a macOS homebrew Formula, and have a workaround in place until this can be merged - would it be possible to create a new release after merging? 