### PR TITLE
Zero out hmac ctx when exiting function like other internal data structures

### DIFF
--- a/src/hmac.c
+++ b/src/hmac.c
@@ -74,6 +74,7 @@ void hmac_sha1(const uint8_t *key, int keyLength,
   memcpy(result, sha, resultLength);
 
   // Zero out all internal data structures
+  explicit_bzero(&ctx, sizeof(ctx));
   explicit_bzero(hashed_key, sizeof(hashed_key));
   explicit_bzero(sha, sizeof(sha));
   explicit_bzero(tmp_key, sizeof(tmp_key));


### PR DESCRIPTION
This explicitly clears the ctx datastructure when generating an hmac, from which the time based authentication is derived.  Its generated keys are already cleared out of the stack as a defense in depth technique, but this clears the intermediate results that the keys are derived from as well.