### PR TITLE
Enable a grace period for two-factor authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,13 @@ timebased, use the `google-authenticator` binary to generate a secret key in
 your home directory with the proper option.  In this mode, clock skew is
 irrelevant and the window size option now applies to how many codes beyond the
 current one that would be accepted, to reduce synchronization problems.
+
+### grace_period=seconds
+
+If present and non-zero, provide a grace period during which a second
+verification code will not be requested. Try setting seconds to 86400
+to allow a full-day between requesting codes; or 3600 for an hour.
+
+This works by adding an (IP address, timestamp) pair to the security
+file after a successful one-time-password login;
+only the last ten distinct IP addresses are tracked.

--- a/src/pam_google_authenticator.c
+++ b/src/pam_google_authenticator.c
@@ -1556,7 +1556,7 @@ update_logindetails(pam_handle_t *pamh, const Params *params, char **buf) {
       continue;
     }
 
-    if (sscanf(line, " %40[0-9a-fA-F:.] %lu ", host, &when) != 2) {
+    if (sscanf(line, " %39[0-9a-fA-F:.] %lu ", host, &when) != 2) {
       log_message(LOG_ERR, pamh, "Malformed LAST%d line", i);
       continue;
     }
@@ -1600,7 +1600,8 @@ update_logindetails(pam_handle_t *pamh, const Params *params, char **buf) {
  * successfully authenticated within the grace period.
  */
 int
-within_grace_period(pam_handle_t *pamh, const Params *params, char *buf) {
+within_grace_period(pam_handle_t *pamh, const Params *params,
+                    const char *buf) {
   const char *rhost = get_rhost(pamh, params);
   const time_t now = get_time();
   const time_t grace = params->grace_period;
@@ -1611,7 +1612,7 @@ within_grace_period(pam_handle_t *pamh, const Params *params, char *buf) {
   if (rhost == NULL) {
     return 0;
   }
-  snprintf(match, sizeof match - 1, " %s %%lu ", rhost);
+  snprintf(match, sizeof match, " %s %%lu ", rhost);
 
   for (int i = 0; i < 10; i++) {
     static char name[] = "LAST0";

--- a/tests/pam_google_authenticator_unittest.c
+++ b/tests/pam_google_authenticator_unittest.c
@@ -93,6 +93,11 @@ int pam_get_item(const pam_handle_t *pamh, int item_type,
       *item = p_conv;
       return PAM_SUCCESS;
     }
+    case PAM_RHOST: {
+        static const char *rhost = "::1";
+        *item = rhost;
+        return PAM_SUCCESS;
+    }
     case PAM_AUTHTOK: {
       static char *authtok = NULL;
       if (conv_mode == COMBINED_PASSWORD) {


### PR DESCRIPTION
Track the last ten IP addresses used to log in, and the time at
which a succesful login attempt occurred.  Add a new 'grace_period'
parameter to the PAM module.    If a new login attempt is made
within grace_period seconds, allow it without requiring
another authentication token.

This addresses github issue #40 and is a version that cleans up all the comments in PR #125 

Signed-off-by: Peter Chubb <peter.chubb@data61.csiro.au>