### PR TITLE
Fixes for authenticator app

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,19 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	[AC_DEFINE([PAM_CONST], [], \
 	[Prevent certain PAM functions from using const arguments])
 	AC_MSG_RESULT([no])])
+
+
+	AC_MSG_CHECKING(whether compiler understands -Wall)
+	old_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS -Wall"
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],
+	  AC_MSG_RESULT(yes),
+	  AC_MSG_RESULT(no)
+	  CFLAGS="$old_CFLAGS")
+
 AC_LANG_POP(C)
+
+
 
 AC_SEARCH_LIBS([dlopen], [dl])
 

--- a/src/google-authenticator.c
+++ b/src/google-authenticator.c
@@ -789,7 +789,7 @@ int main(int argc, char *argv[]) {
       }
     } else {
       const unsigned long tm = 1;
-      printf("Your verification code for code %d is %06d\n",
+      printf("Your verification code for code %lu is %06d\n",
              tm, generateCode(secret, tm));
     }
     printf("Your emergency scratch codes are:\n");
@@ -850,12 +850,15 @@ int main(int argc, char *argv[]) {
       exit(0);
     }
   }
-  secret_fn = realloc(secret_fn, 2*strlen(secret_fn) + 3);
+
+  int len = strlen(secret_fn);
+  /* Note realloc does not zero extra space */
+  secret_fn = realloc(secret_fn, 2 * len + 3);
   if (!secret_fn) {
     perror("malloc()");
     _exit(1);
   }
-  char *tmp_fn = strrchr(secret_fn, '\000') + 1;
+  char *tmp_fn = &secret_fn[len + 1];
   strcat(strcpy(tmp_fn, secret_fn), "~");
 
   // Add optional flags.


### PR DESCRIPTION
The pull series enables -Wall as default (if you're using clang or gcc or other compilers that support the  flag) and fixes two issues:
  -- a mismatch between %ld in a printf and an unsigned long argument
  -- A possible buffer overflow: if the space after string copied by realloc() contains NUL chars, then the strrchr() will pick up the wrong one.  Use strlen() on the original instead.