### PR TITLE
Add 'allow_readonly' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,13 @@ to allow a full-day between requesting codes; or 3600 for an hour.
 This works by adding an (IP address, timestamp) pair to the security
 file after a successful one-time-password login;
 only the last ten distinct IP addresses are tracked.
+
+### allow_readonly
+
+DANGEROUS OPTION!
+
+By default, if the `grace_period` option is defined the PAM module requires
+some free space to store the IP address and timestamp of the last login.
+It could prevent access if a server has no free space or in case of an
+update config file error. With the `allow_readonly` option you can ignore
+any errors which could occur during config file update.


### PR DESCRIPTION
See Issue #13 

Several times we were faced with the situation when we could not log into the server because there was no free space, and the module should update the file due to the grace_period option enabled. As a result, the module failed during file updates and don't give access to the server. 

This fix ignores errors that occur when trying to update the .google_authenticator file but leaves 2FA functionality enabled.