### PR TITLE
Zero fill function for Visual Studio

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -39,11 +39,12 @@
 #include <string.h>
 
 #ifndef HAVE_EXPLICIT_BZERO
-void explicit_bzero(volatile void *s, size_t len)
+void
+explicit_bzero(volatile void *s, size_t len)
 {
-	volatile char *p = (char*)s;
-	while (len--) {
-		*p++ = '\0';
-	}
+  volatile char *p = (char*)s;
+  while (len--) {
+    *p++ = '\0';
+  }
 }
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -39,10 +39,11 @@
 #include <string.h>
 
 #ifndef HAVE_EXPLICIT_BZERO
-void
-explicit_bzero(void *s, size_t len)
+void explicit_bzero(volatile void *s, size_t len)
 {
-  memset(s, '\0', len);
-  asm volatile ("":::"memory");
+	volatile char *p = (char*)s;
+	while (len--) {
+		*p++ = '\0';
+	}
 }
 #endif


### PR DESCRIPTION
Hi,

I used this code and found that "asm" keyword was incompatible with some compilers (especially Visual Studio).

So I fixed explicit_bzero() directly using "while" and here is the result.

Thanks.