### PR TITLE
set variable 'buffer' that in base32_decode to unsigned integer type

### DIFF
--- a/src/base32.c
+++ b/src/base32.c
@@ -20,7 +20,7 @@
 #include "base32.h"
 
 int base32_decode(const uint8_t *encoded, uint8_t *result, int bufSize) {
-  int buffer = 0;
+  unsigned int buffer = 0;
   int bitsLeft = 0;
   int count = 0;
   for (const uint8_t *ptr = encoded; count < bufSize && *ptr; ++ptr) {
@@ -68,7 +68,7 @@ int base32_encode(const uint8_t *data, int length, uint8_t *result,
   }
   int count = 0;
   if (length > 0) {
-    int buffer = data[0];
+    unsigned int buffer = data[0];
     int next = 1;
     int bitsLeft = 8;
     while (count < bufSize && (bitsLeft > 0 || next < length)) {


### PR DESCRIPTION
In base32_decode, variable 'buffer' is signed integer may lead undefined behavior when left operand.

e.g.
compile and link with -fsanitize=undefined, and run test below:
```
const char *b32_key = "PFXWQZLMNRXXO33SNRSA";
unsigned char key[64];
base32_decode((uint8_t*)b32_key, key, sizeof(key));
```
get output: 
> runtime error: left shift of 509336089 by 5 places cannot be represented in type 'int'