### PR TITLE
Resolve issue where grace_period option wouldn't support link-local ipv6 addresses

### DIFF
--- a/src/pam_google_authenticator.c
+++ b/src/pam_google_authenticator.c
@@ -1673,6 +1673,7 @@ within_grace_period(pam_handle_t *pamh, const Params *params,
     char* previous_rhost = malloc((strlen(line) * sizeof(char)) + 1);
 
     if (previous_rhost == NULL) {
+      log_message(LOG_ERR, pamh, "Out of memory");
       return 0;
     }
 

--- a/src/pam_google_authenticator.c
+++ b/src/pam_google_authenticator.c
@@ -1601,7 +1601,7 @@ update_logindetails(pam_handle_t *pamh, const Params *params, char **buf) {
     // But RHOST can be FQDN, and by RFC1035 that's 255 characters as max.
     char host[256];
     unsigned long when = 0; // Timestamp of current entry.
-    const int scanf_rc = sscanf(line, " %255[0-9a-zA-Z:.-%] %lu ", host, &when);
+    const int scanf_rc = sscanf(line, " %255[0-9a-zA-Z:%.-] %lu ", host, &when);
     free(line);
 
     if (scanf_rc != 2) {
@@ -1670,7 +1670,11 @@ within_grace_period(pam_handle_t *pamh, const Params *params,
       continue;
     }
 
-    char* previous_rhost = malloc(strlen(line) * sizeof(char));
+    char* previous_rhost = malloc((strlen(line) * sizeof(char)) + 1);
+
+    if (previous_rhost == NULL) {
+      return 0;
+    }
 
     if (sscanf(line, "%s %lu", previous_rhost, &when) == 2 && strcmp(previous_rhost, rhost) == 0) {
       free(line);


### PR DESCRIPTION
This PR addresses an issue that prevented `grace_period` from supporting link-local IPv6 addresses due to the `%` present in these addresses (e.g. `fe80::84d:ce71:835:830c%en9`).

The issues stem from how the code was currently matching last logins  from the `~/.google_authenticator` file to the remote host.

1. `update_logindetails` wasn't parsing the remote host correctly, resulting in `Malformed LAST%d line` logs. The pattern for matching the host address needed to also match with `%` to support the link-local address format. I simply added `%` to the capture group, but happy to modify if we want it to further limit where `%` can be used.

2. The `within_grace_period` logic was failing to match with previous logins because the `%` was unescaped and present in the `match` string used as the format string in `sscanf`. To resolve this, I changed the `sscanf` call to parse both the hostname and the last login timestamp rather than referencing the host directly in the format string. The comparison b/w previous remote host and remote host is now down in the same conditional. 

Admittedly it's been a while since I've written C, it's possible there may be a better way to resolve this. If there's a strong preference to go with a different approach I'm happy to raise this as an issue in the repo.