### PR TITLE
Use 20-byte secret to match rfc6238

### DIFF
--- a/src/google-authenticator.c
+++ b/src/google-authenticator.c
@@ -37,7 +37,7 @@
 #include "sha1.h"
 
 #define SECRET                    "/.google_authenticator"
-#define SECRET_BITS               128         // Must be divisible by eight
+#define SECRET_BITS               160         // Must be divisible by eight
 #define VERIFICATION_CODE_MODULUS (1000*1000) // Six digits
 #define SCRATCHCODES              5           // Default number of initial scratchcodes
 #define MAX_SCRATCHCODES          10          // Max number of initial scratchcodes


### PR DESCRIPTION
changed secret creation to be 160 bits instead of 128 bits, to align with the rfc6238 reference implementation.